### PR TITLE
feat: Reduce the number of variables by removing existing_resource_group

### DIFF
--- a/cra-config.yaml
+++ b/cra-config.yaml
@@ -16,7 +16,6 @@ CRA_TARGETS:
       TF_VAR_prefix: "rhelai-vpc"
       TF_VAR_region: "eu-es"
       TF_VAR_zone: 2
-      TF_VAR_resource_group: "rhelai-vpc"
       TF_VAR_image_url: "cos://us-east/my-bucket/my-file.qcow2"
       TF_VAR_machine_type: "gx3-24x120x1l40s"
       TF_VAR_ssh_key: "ssh-rsa AAAABBBBCCCC==" # pragma: allowlist secret

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -109,10 +109,8 @@
               "required": true
             },
             {
-              "key": "resource_group"
-            },
-            {
-              "key": "existing_resource_group",
+              "key": "resource_group",
+              "required": true,
               "custom_config": {
                 "type": "resource_group",
                 "grouping": "deployment",
@@ -121,7 +119,7 @@
                   "identifier": "rg_name"
                 }
               }
-            },
+            },            
             {
               "custom_config": {
                 "config_constraints": {

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -119,7 +119,7 @@
                   "identifier": "rg_name"
                 }
               }
-            },            
+            },
             {
               "custom_config": {
                 "config_constraints": {

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -109,7 +109,7 @@
               "required": true
             },
             {
-              "key": "resource_group",
+              "key": "existing_resource_group",
               "required": true,
               "custom_config": {
                 "type": "resource_group",

--- a/solutions/rhelai_vpc/main.tf
+++ b/solutions/rhelai_vpc/main.tf
@@ -9,6 +9,8 @@ locals {
   l_user_zone          = var.zone != null ? "${var.region}-${var.zone}" : null
   l_zone               = var.subnet_id != null ? data.ibm_is_subnet.existing_subnet[0].zone : local.l_user_zone
   l_vpc                = var.subnet_id != null ? data.ibm_is_subnet.existing_subnet[0].vpc : null
+  l_rg                 = var.resource_group == null ? "${var.prefix}-rg-${timestamp()}" : null
+  l_existing_rg        = var.resource_group != null ? var.resource_group : null
 }
 
 data "ibm_is_subnet" "existing_subnet" {
@@ -23,8 +25,8 @@ data "ibm_is_subnet" "existing_subnet" {
 module "resource_group" {
   source                       = "terraform-ibm-modules/resource-group/ibm"
   version                      = "1.1.6"
-  resource_group_name          = var.resource_group
-  existing_resource_group_name = var.existing_resource_group
+  resource_group_name          = local.l_rg
+  existing_resource_group_name = local.l_existing_rg
 }
 
 

--- a/solutions/rhelai_vpc/main.tf
+++ b/solutions/rhelai_vpc/main.tf
@@ -9,7 +9,7 @@ locals {
   l_user_zone          = var.zone != null ? "${var.region}-${var.zone}" : null
   l_zone               = var.subnet_id != null ? data.ibm_is_subnet.existing_subnet[0].zone : local.l_user_zone
   l_vpc                = var.subnet_id != null ? data.ibm_is_subnet.existing_subnet[0].vpc : null
-  l_rg                 = var.resource_group == null ? "${var.prefix}-rg-${timestamp()}" : null
+  l_rg                 = var.resource_group == null ? "${var.prefix}-rg" : null
   l_existing_rg        = var.resource_group != null ? var.resource_group : null
 }
 

--- a/solutions/rhelai_vpc/main.tf
+++ b/solutions/rhelai_vpc/main.tf
@@ -9,8 +9,8 @@ locals {
   l_user_zone          = var.zone != null ? "${var.region}-${var.zone}" : null
   l_zone               = var.subnet_id != null ? data.ibm_is_subnet.existing_subnet[0].zone : local.l_user_zone
   l_vpc                = var.subnet_id != null ? data.ibm_is_subnet.existing_subnet[0].vpc : null
-  l_rg                 = var.resource_group == null ? "${var.prefix}-rg" : null
-  l_existing_rg        = var.resource_group != null ? var.resource_group : null
+  l_rg                 = var.existing_resource_group == null ? "${var.prefix}-rg" : null
+  l_existing_rg        = var.existing_resource_group != null ? var.resource_group : null
 }
 
 data "ibm_is_subnet" "existing_subnet" {

--- a/solutions/rhelai_vpc/main.tf
+++ b/solutions/rhelai_vpc/main.tf
@@ -10,7 +10,7 @@ locals {
   l_zone               = var.subnet_id != null ? data.ibm_is_subnet.existing_subnet[0].zone : local.l_user_zone
   l_vpc                = var.subnet_id != null ? data.ibm_is_subnet.existing_subnet[0].vpc : null
   l_rg                 = var.existing_resource_group == null ? "${var.prefix}-rg" : null
-  l_existing_rg        = var.existing_resource_group != null ? var.resource_group : null
+  l_existing_rg        = var.existing_resource_group != null ? var.existing_resource_group : null
 }
 
 data "ibm_is_subnet" "existing_subnet" {

--- a/solutions/rhelai_vpc/variables.tf
+++ b/solutions/rhelai_vpc/variables.tf
@@ -13,7 +13,7 @@ variable "prefix" {
   description = "Prefix to append to all resources created by this example"
 }
 
-variable "resource_group" {
+variable "existing_resource_group" {
   type        = string
   description = "The name of a new resource group to provision resources in."
   default     = null

--- a/solutions/rhelai_vpc/variables.tf
+++ b/solutions/rhelai_vpc/variables.tf
@@ -17,17 +17,6 @@ variable "resource_group" {
   type        = string
   description = "The name of a new resource group to provision resources in."
   default     = null
-
-  validation {
-    condition     = var.resource_group != null || var.existing_resource_group != null
-    error_message = "You must supply either a new resource group name (resource_group) or an existing resource group name (existing_resource_group)."
-  }
-}
-
-variable "existing_resource_group" {
-  type        = string
-  description = "The name of a existing resource group to provision resources in. Do not set if you fill resource_group"
-  default     = null
 }
 
 variable "region" {

--- a/solutions/rhelai_vpc/variables.tf
+++ b/solutions/rhelai_vpc/variables.tf
@@ -15,7 +15,7 @@ variable "prefix" {
 
 variable "existing_resource_group" {
   type        = string
-  description = "The name of a new resource group to provision resources in."
+  description = "Select the name of a existing resource group or select NULL to create new resource group."
   default     = null
 }
 


### PR DESCRIPTION
…name else use the existing provided under resource_group_name. This will reduce the number of parameters

### Description

While choosing the resource group, If NULL is provided then generate a name using prefix and timestamp else use the existing provided under resource_group_name. This will reduce the number of parameters

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`0.3.1`)
- [ ] Major release (`X.x.x`)

##### Release notes content

**Feature Update**
While choosing the resource group, If NULL is provided then generate a name using prefix and timestamp else use the existing provided under resource_group_name. This will reduce the number of parameters

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
