### PR TITLE
fix: on second run with change from https to http we should be able t…

### DIFF
--- a/modules/model/main.tf
+++ b/modules/model/main.tf
@@ -39,7 +39,8 @@ resource "terraform_data" "setup_ansible_host" {
     var.model_cos_region,
     var.ibmcloud_api_key,
     var.model_apikey,
-    var.num_gpus
+    var.num_gpus,
+    var.model_host
   ]
 
 
@@ -140,7 +141,8 @@ resource "terraform_data" "execute_playbooks" {
     var.model_bucket_name,
     var.model_cos_region,
     var.ibmcloud_api_key,
-    var.num_gpus
+    var.num_gpus,
+    var.model_host
   ]
 
   connection {
@@ -172,7 +174,8 @@ resource "terraform_data" "clear_ansible_files" {
     var.model_cos_region,
     var.ibmcloud_api_key,
     var.model_bucket_crn,
-    var.num_gpus
+    var.num_gpus,
+    var.model_host
   ]
 
   depends_on = [terraform_data.execute_playbooks]


### PR DESCRIPTION
…o run the model on port 0.0.0.0

### Description

Fix: HTTPS to HTTP changes on second run may not have the right host set while running the model

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`0.3.6`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Fix: HTTPS to HTTP changes on second run may not have the right host set while running the model

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
